### PR TITLE
Refactor extract history service

### DIFF
--- a/NotesApp/Program.cs
+++ b/NotesApp/Program.cs
@@ -6,13 +6,12 @@ using NotesApp.Services.Interfaces;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container
-var connectionString = builder.Configuration.GetConnectionString("DefaultConnection") ??
-    throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
+var connectionString = builder.Configuration
+    .GetConnectionString("DefaultConnection")
+    ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlite(connectionString));
 
-// Configure Identity with proper settings
 builder.Services.AddIdentity<IdentityUser, IdentityRole>(options =>
 {
     options.SignIn.RequireConfirmedAccount = false;
@@ -26,16 +25,17 @@ builder.Services.AddIdentity<IdentityUser, IdentityRole>(options =>
     .AddEntityFrameworkStores<ApplicationDbContext>()
     .AddDefaultTokenProviders();
 
-// Register our custom services
 builder.Services.AddScoped<PasswordService>();
 builder.Services.AddScoped<AuthService>();
 builder.Services.AddScoped<NoteService>();
 builder.Services.AddScoped<ITagRepository, TagRepository>();
 
+builder.Services.AddScoped<IHistoryService, HistoryService>();
+builder.Services.AddHttpContextAccessor();
+
 builder.Services.AddControllersWithViews();
 builder.Services.AddRazorPages();
 
-// Configure cookie settings
 builder.Services.ConfigureApplicationCookie(options =>
 {
     options.LoginPath = "/Account/Login";
@@ -45,29 +45,21 @@ builder.Services.ConfigureApplicationCookie(options =>
 
 var app = builder.Build();
 
-// Apply migrations and seed initial data
 using (var scope = app.Services.CreateScope())
 {
     var services = scope.ServiceProvider;
     try
     {
-        var context = services.GetRequiredService<ApplicationDbContext>();
-        var userManager = services.GetRequiredService<UserManager<IdentityUser>>();
-        var roleManager = services.GetRequiredService<RoleManager<IdentityRole>>();
-
-        // Apply pending migrations
-        context.Database.Migrate();
-
-
+        var db = services.GetRequiredService<ApplicationDbContext>();
+        db.Database.Migrate();
     }
     catch (Exception ex)
     {
         var logger = services.GetRequiredService<ILogger<Program>>();
-        logger.LogError(ex, "An error occurred while migrating or seeding the database.");
+        logger.LogError(ex, "Error during migration");
     }
 }
 
-// Configure the HTTP request pipeline
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Home/Error");
@@ -77,13 +69,12 @@ if (!app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 app.UseStaticFiles();
 app.UseRouting();
-
 app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllerRoute(
     name: "default",
     pattern: "{controller=Home}/{action=Index}/{id?}");
-app.MapRazorPages();  // Important for Identity pages
+app.MapRazorPages();
 
 app.Run();

--- a/NotesApp/Services/HistoryService.cs
+++ b/NotesApp/Services/HistoryService.cs
@@ -1,0 +1,11 @@
+﻿using System;
+namespace NotesApp.Services
+{
+	public class HistoryService
+	{
+		public HistoryService()
+		{
+		}
+	}
+}
+

--- a/NotesApp/Services/HistoryService.cs
+++ b/NotesApp/Services/HistoryService.cs
@@ -1,11 +1,85 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using NotesApp.Data;
+using NotesApp.Models;
+using NotesApp.Services.Interfaces;
+
 namespace NotesApp.Services
 {
-	public class HistoryService
-	{
-		public HistoryService()
-		{
-		}
-	}
-}
+    public class HistoryService : IHistoryService
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
+        public HistoryService(ApplicationDbContext context,
+                              IHttpContextAccessor httpContextAccessor)
+        {
+            _context = context;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public async Task RecordAsync(int noteId, string action, string title, string content)
+        {
+            var username = _httpContextAccessor
+                               .HttpContext?
+                               .User?
+                               .Identity?
+                               .Name
+                           ?? "Unknown";
+
+            var history = new NoteHistory
+            {
+                NoteId = noteId,
+                ChangeType = action,
+                Title = title,
+                Content = content,
+                ChangedAt = DateTime.UtcNow,
+                ChangedBy = username
+            };
+
+            _context.NoteHistories.Add(history);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task<List<NoteHistory>> GetAllAsync(int? tagId = null)
+        {
+            var query = _context.NoteHistories
+                .Include(h => h.Note)
+                    .ThenInclude(n => n.NoteTags)
+                        .ThenInclude(nt => nt.Tag)
+                .AsQueryable();
+
+            if (tagId.HasValue)
+            {
+                query = query.Where(h =>
+                    h.Note.NoteTags.Any(nt => nt.TagId == tagId.Value));
+            }
+
+            return await query
+                .OrderByDescending(h => h.ChangedAt)
+                .ToListAsync();
+        }
+
+        public async Task ClearAllAsync()
+        {
+            _context.NoteHistories.RemoveRange(_context.NoteHistories);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task ClearByTagAsync(int tagId)
+        {
+            var toDelete = _context.NoteHistories
+                .Include(h => h.Note)
+                    .ThenInclude(n => n.NoteTags)
+                .Where(h =>
+                    h.Note.NoteTags.Any(nt => nt.TagId == tagId));
+
+            _context.NoteHistories.RemoveRange(toDelete);
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/NotesApp/Services/Interfaces/IHistoryService.cs
+++ b/NotesApp/Services/Interfaces/IHistoryService.cs
@@ -1,0 +1,8 @@
+﻿using System;
+namespace NotesApp.Services.Interfaces
+{
+	public interface IHistoryService
+	{
+	}
+}
+

--- a/NotesApp/Services/Interfaces/IHistoryService.cs
+++ b/NotesApp/Services/Interfaces/IHistoryService.cs
@@ -1,8 +1,14 @@
-﻿using System;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using NotesApp.Models;
+
 namespace NotesApp.Services.Interfaces
 {
-	public interface IHistoryService
-	{
-	}
+    public interface IHistoryService
+    {
+        Task RecordAsync(int noteId, string action, string title, string content);
+        Task<List<NoteHistory>> GetAllAsync(int? tagId = null);
+        Task ClearAllAsync();
+        Task ClearByTagAsync(int tagId);
+    }
 }
-


### PR DESCRIPTION
## Problem:
- Both NotesController and HistoryController contain duplicated EF Core logic for recording, querying, and clearing note histories.
- Controllers handle persistence and HTTP concerns together, violating the Single Responsibility Principle.
- Scattered history code makes it hard to maintain, extend, or unit-test history-related functionality.

## Solution:
- Introduced IHistoryService (in Services/Interfaces/IHistoryService.cs) to define history operations.
- Implemented HistoryService (in Services/HistoryService.cs) that encapsulates all history logging, querying, and clearing logic, using IHttpContextAccessor to capture the current user.
- Registered IHistoryService → HistoryService and IHttpContextAccessor in Program.cs.
- Refactored NotesController to call IHistoryService.RecordAsync(...) instead of its private RecordHistory method.
- Refactored HistoryController to delegate all history reads and clears to IHistoryService and removed direct DbContext usage.

## Benefits:
- SRP & DRY: All history-related behavior lives in one service, not scattered across controllers.
- Maintainability: To change history rules (add new fields), update only HistoryService.
- Cleaner Controllers: Controllers now focus solely on HTTP and orchestration.
